### PR TITLE
chore: adapt to `decide := false` in simp

### DIFF
--- a/Aesop/Options/Public.lean
+++ b/Aesop/Options/Public.lean
@@ -134,7 +134,7 @@ structure Options where
 /--
 Options which modify the behaviour of the builtin `simp` normalisation rule.
 Extends `Lean.Meta.Simp.ConfigCtx`, so any option declared there is also valid
-here. For example, you can use `aesop (simp_config := { arith := true })` to get
+here. For example, you can use `aesop (simp_options := { arith := true })` to get
 behaviour similar to `simp (config := { arith := true })` (aka `simp_arith`).
 -/
 structure SimpConfig extends Lean.Meta.Simp.ConfigCtx where

--- a/Aesop/Search/Expansion/Norm.lean
+++ b/Aesop/Search/Expansion/Norm.lean
@@ -387,7 +387,7 @@ partial def normalizeGoalMVar (goal : MVarId)
     NormStep.simp mvarsHashSet,
     NormStep.runPostSimpRules mvars
   ]
-  runNormSteps goal normSteps (by simp)
+  runNormSteps goal normSteps (by simp (config := { decide := true }))
 
 -- Returns true if the goal was solved by normalisation.
 def normalizeGoalIfNecessary (gref : GoalRef) [Aesop.Queue Q] :


### PR DESCRIPTION
Future-proofing for leanprover/lean4#2722. A comment on `SimpConfig` is missing but I didn't exactly know what to write.