### PR TITLE
Update README.md `trace.aesop.finalTree` => `trace.aesop.tree`

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ set_option trace.aesop true
 
 This makes Aesop print out the steps it takes while searching for a proof. You
 can also look at the search tree Aesop constructed by enabling the
-`trace.aesop.finalTree` option. For more tracing options, type `set_option
+`trace.aesop.tree` option. For more tracing options, type `set_option
 trace.aesop` and see what auto-completion suggests.
 
 If, in the example above, you call `aesop?` instead, then Aesop prints a proof


### PR DESCRIPTION
The README mentions option `trace.aesop.finalTree`, which does not seem to exist. I'm assuming the option referenced at that point in the README is now called `tree`.