### PR TITLE
chore: fix imports

### DIFF
--- a/Aesop/Script.lean
+++ b/Aesop/Script.lean
@@ -10,6 +10,7 @@ import Aesop.Util.EqualUpToIds
 import Std.Lean.Meta.Clear
 import Std.Lean.Meta.Inaccessible
 import Std.Lean.HashSet
+import Std.Tactic.Ext
 
 open Lean
 open Lean.Elab.Tactic

--- a/Aesop/Search/Queue.lean
+++ b/Aesop/Search/Queue.lean
@@ -8,7 +8,7 @@ import Aesop.Options
 import Aesop.Tracing
 import Aesop.Tree
 import Aesop.Search.Queue.Class
-import Std.Data.BinomialHeap
+import Std.Data.BinomialHeap.Basic
 
 open Lean
 open Std (BinomialHeap)

--- a/Aesop/Util/UnionFind.lean
+++ b/Aesop/Util/UnionFind.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Jannis Limperg
 -/
 
-import Std.Data.HashMap
+import Std.Data.HashMap.Basic
 
 open Std (HashMap)
 


### PR DESCRIPTION
This is a pre-patch for [std4#379](https://github.com/leanprover/std4/pull/379). It only replaces some imports by more precise ones. It is intended to be applied *before* std4#379, that will prevent breakage if and when that PR happens and it is otherwise completely harmless for aesop.