### PR TITLE
chore: fix deprecations hidden by dot notation

### DIFF
--- a/Aesop/Builder/Forward.lean
+++ b/Aesop/Builder/Forward.lean
@@ -74,7 +74,7 @@ def getImmediatePremises (stx : Term) (type : Expr) (pat? : Option RulePattern)
     -- If immediate names are given, we check that corresponding arguments
     -- exists and record these arguments' positions.
     withTransparency md $ forallTelescopeReducing type λ args _ => do
-      let mut unseen := immediate.sortAndDeduplicate (ord := ⟨Name.quickCmp⟩)
+      let mut unseen := immediate.sortDedup (ord := ⟨Name.quickCmp⟩)
       let mut result := #[]
       for h : i in [:args.size] do
         let argName := (← args[i].fvarId!.getDecl).userName

--- a/Aesop/RuleTac/Forward.lean
+++ b/Aesop/RuleTac/Forward.lean
@@ -127,7 +127,7 @@ def applyForwardRule (goal : MVarId) (e : Expr) (pat? : Option RulePattern)
       newHypProofs := newHypProofs'
       usedHyps := usedHyps'
     usedHyps :=
-      usedHyps.sortAndDeduplicate (ord := ⟨λ x y => x.name.quickCmp y.name⟩)
+      usedHyps.sortDedup (ord := ⟨λ x y => x.name.quickCmp y.name⟩)
     if newHypProofs.isEmpty then
       err
     let forwardHypTypes ← getForwardHypTypes

--- a/Aesop/Tree/UnsafeQueue.lean
+++ b/Aesop/Tree/UnsafeQueue.lean
@@ -71,7 +71,7 @@ def initial (postponedSafeRules : Array PostponedSafeRule)
   let postponedSafeRules :=
     postponedSafeRules.map .postponedSafeRule
       |>.qsort (λ x y => compare x y |>.isLT)
-  postponedSafeRules.mergeSortedDeduplicating unsafeRules |>.toSubarray
+  postponedSafeRules.mergeDedup unsafeRules |>.toSubarray
 
 def entriesToMessageData (q : UnsafeQueue) : Array MessageData :=
   q.toArray.map toMessageData

--- a/Aesop/Util/UnorderedArraySet.lean
+++ b/Aesop/Util/UnorderedArraySet.lean
@@ -41,13 +41,13 @@ protected def ofDeduplicatedArray (xs : Array α) : UnorderedArraySet α :=
 
 /-- Precondition: `xs` is sorted. -/
 protected def ofSortedArray (xs : Array α) : UnorderedArraySet α :=
-  ⟨xs.deduplicateSorted⟩
+  ⟨xs.dedupSorted⟩
 
 set_option linter.unusedVariables false in
 /-- O(n*log(n)) -/
 protected def ofArray [ord : Ord α] [Inhabited α] (xs : Array α) :
     UnorderedArraySet α :=
-  ⟨xs.sortAndDeduplicate⟩
+  ⟨xs.sortDedup⟩
 
 /-- O(n^2) -/
 protected def ofArraySlow (xs : Array α) : UnorderedArraySet α :=
@@ -77,7 +77,7 @@ def filter (p : α → Bool) (s : UnorderedArraySet α) : UnorderedArraySet α :
 
 /-- O(n*m) -/
 def merge (s t : UnorderedArraySet α) : UnorderedArraySet α :=
-  ⟨s.rep.mergeUnsortedDeduplicating t.rep⟩
+  ⟨s.rep.mergeUnsortedDedup t.rep⟩
 
 instance : Append (UnorderedArraySet α) :=
   ⟨merge⟩


### PR DESCRIPTION
In preparation for https://github.com/leanprover/lean4/pull/3969 landing, we fix some deprecation warnings.