### PR TITLE
chore: switch to lean-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,14 +13,6 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v2
-    - name: Install Elan
-      run: |
-        set -o pipefail
-        curl -sSfL https://github.com/leanprover/elan/releases/download/v1.4.2/elan-x86_64-unknown-linux-gnu.tar.gz | tar xz
-        ./elan-init -y --default-toolchain none
-        echo "$HOME/.elan/bin" >> $GITHUB_PATH
-    - name: Build
-      run: lake build
-    - name: Run tests
-      run: lake test
+      - uses: leanprover/lean-action@v1-alpha
+        with:
+          check-reservoir-eligibility: true


### PR DESCRIPTION
Convert existing CI to use `lean-action`.

I did a test run of the workflow on my fork [here](https://github.com/austinletson/aesop/actions/runs/9063431865/job/24899356289?pr=1)

Additional CI features added through lean-action:

- .lake caching across runs
- check reservoir eligibility  