### PR TITLE
feat: print first goal after safe prefix in terminal mode

### DIFF
--- a/Aesop/Util/Basic.lean
+++ b/Aesop/Util/Basic.lean
@@ -362,12 +362,4 @@ register_option aesop.smallErrorMessages : Bool := {
     descr := "(aesop) Print smaller error messages. Used for testing."
   }
 
-def throwAesopEx (mvarId : MVarId) (msg? : Option MessageData) : MetaM α := do
-  if aesop.smallErrorMessages.get (← getOptions) then
-    match msg? with
-    | none => throwError "tactic 'aesop' failed"
-    | some msg => throwError "tactic 'aesop' failed, {msg}"
-  else
-    throwTacticEx `aesop mvarId msg?
-
 end Aesop

--- a/AesopTest/RulePattern.lean
+++ b/AesopTest/RulePattern.lean
@@ -51,7 +51,8 @@ axiom falso' : True → False
 
 /--
 error: tactic 'aesop' failed, made no progress
-⊢ False
+Initial goal:
+  ⊢ False
 -/
 #guard_msgs in
 example : False := by

--- a/AesopTest/SafePrefixExpansionRappLimit.lean
+++ b/AesopTest/SafePrefixExpansionRappLimit.lean
@@ -10,14 +10,27 @@ import Aesop
 axiom loopy {α : Prop} : α ∨ α → α
 
 /--
-warning: aesop: safe prefix was not fully expanded because the maximum number of rule applications (50) was reached.
----
 warning: aesop: failed to prove the goal. Some goals were not explored because the maximum rule application depth (30) was reached. Set option 'maxRuleApplicationDepth' to increase the limit.
+---
+warning: aesop: safe prefix was not fully expanded because the maximum number of rule applications (50) was reached.
 ---
 error: unsolved goals
 case a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a
 ⊢ False
 -/
 #guard_msgs in
-example : false := by
+example : False := by
   aesop
+
+/--
+error: tactic 'aesop' failed, failed to prove the goal. Some goals were not explored because the maximum rule application depth (30) was reached. Set option 'maxRuleApplicationDepth' to increase the limit.
+Initial goal:
+  ⊢ False
+Remaining goals after safe rules:
+  case a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a.a
+  ⊢ False
+The safe prefix was not fully expanded because the maximum number of rule applications (50) was reached.
+-/
+#guard_msgs in
+example : False := by
+  aesop (config := { terminal := true })

--- a/AesopTest/SafePrefixInTerminalError.lean
+++ b/AesopTest/SafePrefixInTerminalError.lean
@@ -1,0 +1,9 @@
+import Aesop
+
+/--
+error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
+a b : Nat
+⊢ a + b = b + 2 * a
+-/
+#guard_msgs in
+example : ∀ (a b : Nat), a + b = b + 2 * a := by aesop (config := { terminal := true })

--- a/AesopTest/SafePrefixInTerminalError.lean
+++ b/AesopTest/SafePrefixInTerminalError.lean
@@ -2,8 +2,12 @@ import Aesop
 
 /--
 error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
-a b : Nat
-⊢ a + b = b + 2 * a
+Initial goal:
+  ⊢ ∀ (a b : Nat), a + b = b + 2 * a
+Remaining goals after safe rules:
+  a b : Nat
+  ⊢ a + b = b + 2 * a
 -/
 #guard_msgs in
-example : ∀ (a b : Nat), a + b = b + 2 * a := by aesop (config := { terminal := true })
+example : ∀ (a b : Nat), a + b = b + 2 * a := by
+  aesop (config := { terminal := true })

--- a/AesopTest/TerminalError.lean
+++ b/AesopTest/TerminalError.lean
@@ -10,7 +10,10 @@ set_option aesop.check.all true
 
 /--
 error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
-⊢ False
+Initial goal:
+  ⊢ False
+Remaining goals after safe rules:
+  ⊢ False
 -/
 #guard_msgs in
 example : False := by

--- a/AesopTest/TraceProof.lean
+++ b/AesopTest/TraceProof.lean
@@ -13,6 +13,8 @@ set_option trace.aesop.proof true
 
 /--
 error: tactic 'aesop' failed, made no progress
+---
+info: [aesop.proof] <no proof>
 -/
 #guard_msgs in
 example : α := by


### PR DESCRIPTION
When in terminal mode, print the (first) goal after the terminal prefix as part of the error message, so we get an indication of what progress aesop made, and where it got stuck.

Too often I write a structure where some auto_param field is not successfully filled in by `aesop`, and it's presumably just because a `@[simp]` lemma is missing. But to see the goal (and hence deduce the missing simp lemma), I have to add ` field := by aesop`. I think with this change we'll just be able to see what we need immediately.