### PR TITLE
chore: upgrade `lean-action` to `v1-beta`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         os: [ubuntu-latest]
     steps:
-      - uses: leanprover/lean-action@v1-alpha
+      - uses: actions/checkout@v4
+
+      - uses: leanprover/lean-action@v1-beta
         with:
           check-reservoir-eligibility: true


### PR DESCRIPTION
add `actions/checkout` as this was removed from `lean-action` in `v1-beta`