### PR TITLE
chore: modify `MonadStats` to not extend parents multiple times

### DIFF
--- a/Aesop/Stats/Basic.lean
+++ b/Aesop/Stats/Basic.lean
@@ -175,11 +175,11 @@ end Stats
 
 abbrev StatsRef := IO.Ref Stats
 
-class MonadStats (m) extends
-    MonadLiftT (ST IO.RealWorld) m,
-    MonadLiftT BaseIO m,
-    MonadOptions m where
+class MonadStats (m) extends MonadOptions m where
+  [instLift : MonadLiftT BaseIO m]
   readStatsRef : m StatsRef
+
+instance [MonadStats m] : MonadLift BaseIO m := ⟨MonadStats.instLift.monadLift⟩
 
 export MonadStats (readStatsRef)
 


### PR DESCRIPTION
MonadStats was extending `MonadLiftT` twice, but the two parents were defeq. This was a hack to get around the fact that the parent instances were providing `MonadLiftT` instances rather than a `MonadLift` instance, breaking `MonadLiftT` inference.

This changes it to *not* extend `MonadLiftT`, instead embedding it as a field, and then writing an explicit `MonadLift` instance. While it could still extend the `MonadLiftT` instance, it is better this way because no one should be providing `MonadLiftT` instances.

This is motivated by [lean4#5770](https://github.com/leanprover/lean4/pull/5770), which will log warnings when structures extend parents multiple times.