### PR TITLE
Script.SpecificTactics: fix generated `simp (config := ...)` syntax

### DIFF
--- a/Aesop/Script/SpecificTactics.lean
+++ b/Aesop/Script/SpecificTactics.lean
@@ -139,11 +139,11 @@ private def simpAllOrSimpAtStarStx [Monad m] [MonadQuotation m] (simpAll : Bool)
   if simpAll then
     match configStx? with
     | none => `(tactic| simp_all)
-    | some cfg => `(tactic| simp_all (config := $cfg))
+    | some cfg => `(tactic| simp_all ($(mkIdent `config):ident := $cfg))
   else
     match configStx? with
     | none => `(tactic| simp at *)
-    | some cfg => `(tactic| simp (config := $cfg) at *)
+    | some cfg => `(tactic| simp ($(mkIdent `config):ident := $cfg) at *)
 
 private def simpAllOrSimpAtStarOnlyStx (simpAll : Bool) (inGoal : MVarId)
     (configStx? : Option Term) (usedTheorems : Simp.UsedSimps) :

--- a/AesopTest/ScriptWithOptions.lean
+++ b/AesopTest/ScriptWithOptions.lean
@@ -8,11 +8,9 @@ import Aesop
 
 set_option aesop.check.all true
 
--- FIXME: the tombstone in the "try this" suggestion below appeared in nightly-2024-11-03,
--- presumably because of https://github.com/leanprover/lean4/pull/5898
 /--
 info: Try this:
-simp_all (config✝ := { }) only
+simp_all (config := { }) only
 -/
 #guard_msgs in
 example : True := by


### PR DESCRIPTION
See https://leanprover.zulipchat.com/#narrow/channel/113488-general/topic/aesop.20try.20this.20regression
