### PR TITLE
Stats.Extension: fix panics due to async elaboration

### DIFF
--- a/Aesop/Stats/Extension.lean
+++ b/Aesop/Stats/Extension.lean
@@ -49,6 +49,7 @@ initialize statsExtension : StatsExtension ←
   registerSimplePersistentEnvExtension {
     addEntryFn := λ _ _ => ()
     addImportedFn := λ _ => ()
+    asyncMode := .sync -- Maybe we could use a less restrictive mode, but (a) it's not clear to me and (b) this extension is unused by default.
   }
 
 def recordStatsIfEnabled [Monad m] [MonadEnv m] [MonadOptions m]

--- a/AesopTest/Stats.lean
+++ b/AesopTest/Stats.lean
@@ -1,0 +1,22 @@
+/-
+Copyright (c) 2025 Jannis Limperg. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Jannis Limperg
+-/
+
+import Aesop
+
+/-
+Regression test for a bug involving the stats extension and async elaboration.
+The commands below should not panic and should show non-zero stats.
+-/
+
+set_option aesop.collectStats true
+set_option trace.aesop.stats true
+
+#guard_msgs (drop info) in
+theorem mem_spec {o : Option α} : a ∈ o ↔ o = some a := by
+  aesop (add norm simp Membership.mem)
+
+#guard_msgs (drop info) in
+#aesop_stats


### PR DESCRIPTION
The stats extension had the wrong async mode, leading to panics.