### PR TITLE
style: replace `HEq x y` with `x ≍ y`

### DIFF
--- a/Aesop/BuiltinRules.lean
+++ b/Aesop/BuiltinRules.lean
@@ -55,7 +55,7 @@ attribute [aesop (rule_sets := [builtin]) norm constructors] ULift
 attribute [aesop (rule_sets := [builtin]) norm 0 destruct] ULift.down
 
 @[aesop (rule_sets := [builtin]) norm simp]
-theorem heq_iff_eq (x y : α) : HEq x y ↔ x = y :=
+theorem heq_iff_eq (x y : α) : x ≍ y ↔ x = y :=
   ⟨eq_of_heq, heq_of_eq⟩
 
 end Aesop.BuiltinRules

--- a/AesopTest/27.lean
+++ b/AesopTest/27.lean
@@ -49,21 +49,21 @@ theorem All.split_cons₂ (P : α → Prop) (x : α) (xs : List α) (h : All P (
   : P x ∧ All P xs :=
       (fun (h_1 : All P (x :: xs)) =>
           ((fun (h_2 : All P (x :: xs)) =>
-                (All.casesOn (P := P) (motive := fun a x_1 => x :: xs = a → HEq h x_1 → P x ∧ All P xs) h_2
+                (All.casesOn (P := P) (motive := fun a x_1 => x :: xs = a → h ≍ x_1 → P x ∧ All P xs) h_2
                     (fun h_1 => List.noConfusion h_1) fun {x_1} {xs_1} a a_1 h_1 =>
                     List.noConfusion h_1 fun head_eq =>
                       Eq.ndrec (motive := fun {x_1} =>
-                        ∀ (a : P x_1), xs = xs_1 → HEq h (All.cons (P := P) a a_1) → P x ∧ All P xs)
+                        ∀ (a : P x_1), xs = xs_1 → h ≍ All.cons (P := P) a a_1 → P x ∧ All P xs)
                         (fun a tail_eq =>
                           Eq.ndrec (motive := fun {xs_1} =>
-                            ∀ (a_1 : All P xs_1), HEq h (All.cons (P := P) a a_1) → P x ∧ All P xs)
+                            ∀ (a_1 : All P xs_1), h ≍ All.cons (P := P) a a_1 → P x ∧ All P xs)
                             (fun a_1 h_1 =>
                               Eq.ndrec (motive := fun h => P x ∧ All P xs)
                                 (of_eq_true (Eq.trans (congr (congrArg And (eq_true a)) (eq_true a_1)) (and_self True)))
                                 (Eq.symm (eq_of_heq h_1)))
                             tail_eq a_1)
                         head_eq a :
-                  x :: xs = x :: xs → HEq h h_2 → P x ∧ All P xs))
+                  x :: xs = x :: xs → h ≍ h_2 → P x ∧ All P xs))
               h_1 :
-            x :: xs = x :: xs → HEq h h_1 → P x ∧ All P xs))
+            x :: xs = x :: xs → h ≍ h_1 → P x ∧ All P xs))
         h (Eq.refl (x :: xs)) (HEq.refl h)

--- a/AesopTest/Subst.lean
+++ b/AesopTest/Subst.lean
@@ -73,11 +73,11 @@ example (h₁ : P ↔ Q) (h₂ : Q ↔ R) (h₃ : P) : R  := by
 error: tactic 'aesop' failed, failed to prove the goal after exhaustive search.
 -/
 #guard_msgs in
-example {P : α → Prop} {x y z : α} (h₁ : HEq x y) (h₂ : HEq y z) (h₃ : P x) :
+example {P : α → Prop} {x y z : α} (h₁ : x ≍ y) (h₂ : y ≍ z) (h₃ : P x) :
     P z  := by
   aesop (erase Aesop.BuiltinRules.subst)
     (config := { useSimpAll := false, terminal := true })
 
-example {P : α → Prop} {x y z : α} (h₁ : HEq x y) (h₂ : HEq y z) (h₃ : P x) :
+example {P : α → Prop} {x y z : α} (h₁ : x ≍ y) (h₂ : y ≍ z) (h₃ : P x) :
     P z  := by
   aesop (config := { useSimpAll := false })


### PR DESCRIPTION
The notation `≍` for `HEq` was introduced in leanprover/lean4#8503 and has not yet been included in v4.21.0-rc3, but in leanprover/lean4#8872, the core library replaced all instances of `HEq x y` with `x ≍ y`.
This PR applies the same replacement in Aesop.