### PR TITLE
fix: pretty-printing of `declare_aesop_rulesets`

### DIFF
--- a/Aesop/Frontend/Command.lean
+++ b/Aesop/Frontend/Command.lean
@@ -16,7 +16,7 @@ namespace Aesop.Frontend.Parser
 
 syntax (name := declareRuleSets)
   "declare_aesop_rule_sets " "[" ident,+,? "]"
-  ("(" &"default" " := " Aesop.bool_lit ")")? : command
+  (" (" &"default" " := " Aesop.bool_lit ")")? : command
 
 elab_rules : command
   | `(declare_aesop_rule_sets [ $ids:ident,* ]


### PR DESCRIPTION
I think that this will add a space in the correct position.  Here is a test to try out:
```lean
import Aesop.Frontend.Command

/-- info: declare_aesop_rule_sets [A](default := true) -/
#guard_msgs in
run_cmd
  let id := Lean.mkIdent `A
  let stx ← `(declare_aesop_rule_sets [$id] (default := true))
  Lean.logInfo stx
```

After the change, I think that there will be a space between the parentheses in `[A](default`.