### PR TITLE
Forward/RPINF: use reducible+instances transparency

### DIFF
--- a/Aesop/Forward/RuleInfo.lean
+++ b/Aesop/Forward/RuleInfo.lean
@@ -84,7 +84,7 @@ def ofExpr (thm : Expr) (rulePattern? : Option RulePattern)
   let numLevelParams :=
     (collectLevelParams {} e).params.size +
     (collectLevelMVars {} e).result.size
-  let (premises, _, conclusion) ← withReducible $ forallMetaTelescope e
+  let (premises, _, conclusion) ← withReducible do forallMetaTelescope e
   let premises := premises.map (·.mvarId!)
   let mut premiseToIdx : Std.HashMap MVarId PremiseIndex := ∅
   for h : i in [:premises.size] do

--- a/Aesop/Forward/State.lean
+++ b/Aesop/Forward/State.lean
@@ -392,7 +392,7 @@ def matchPremise? (premises : Array MVarId) (lmvarIds : Array LMVarId)
   withoutModifyingState do
     let isDefEq ←
       withConstAesopTraceNode .forwardDebug (return m!"defeq check") do
-      withReducible do
+      withReducibleAndInstances do
         isDefEq premiseType hypType
     if isDefEq then
       let mut subst := .empty premises.size lmvarIds.size
@@ -661,7 +661,7 @@ def addRawHyp (goal : MVarId) (h : RawHyp) (pi : PremiseIndex) (rs : RuleState) 
     let ruleType ← instantiateMVars (← inferType ruleExpr)
     let (premises, _, _) ←
       withConstAesopTraceNode .forwardDebug (return m!"open rule term") do
-      withReducible do
+      withReducibleAndInstances do
         forallMetaTelescope ruleType
     if premises.size != rs.rule.numPremises then
       aesop_trace[forward] "failed to add hyp or pat inst: rule term{indentD $ toMessageData rs.rule.term}\ndoes not have expected number of premises {rs.rule.numPremises}"

--- a/Aesop/RPINF.lean
+++ b/Aesop/RPINF.lean
@@ -43,7 +43,9 @@ where
           mkForallFVars xs (← go e)
       | .proj t i e =>
         return .proj t i (← go e)
-      | .sort .. | .mvar .. | .lit .. | .const .. | .fvar .. =>
+      | .sort u => return .sort <| ← normalizeLevel u
+      | .const n us => return .const n <| ← us.mapM fun u => normalizeLevel u
+      | .mvar .. | .lit .. | .fvar .. =>
         return e
       | .letE .. | .mdata .. | .bvar .. => unreachable!
 

--- a/Aesop/RPINF.lean
+++ b/Aesop/RPINF.lean
@@ -12,7 +12,7 @@ local instance : MonadCache Expr Expr BaseM where
 
 @[specialize]
 partial def rpinfRaw (e : Expr) : BaseM RPINFRaw :=
-  withReducible do return ⟨← go e⟩
+  withReducibleAndInstances do return ⟨← go e⟩
 where
   go (e : Expr) : BaseM Expr :=
     withIncRecDepth do

--- a/Aesop/RPINF/Basic.lean
+++ b/Aesop/RPINF/Basic.lean
@@ -29,19 +29,18 @@ mutual
   expressions are type-correct, in PINF and have defeq types. -/
   def pinfEqCore : (x y : Expr) → Bool
     | .bvar i₁, .bvar i₂ => i₁ == i₂
-    | .fvar id₁, .fvar id₂ => id₁ == id₂
+    | .fvar id₁, .fvar id₂
     | .mvar id₁, .mvar id₂ => id₁ == id₂
     | .sort u, .sort v => u == v
     | .const n₁ us, .const n₂ vs => n₁ == n₂ && us == vs
     | .app f₁ e₁, .app f₂ e₂ => pinfEq f₁ f₂ && pinfEq e₁ e₂
-    | .lam _ t₁ e₁ bi₁, .lam _ t₂ e₂ bi₂ =>
-      bi₁ == bi₂ && pinfEq t₁ t₂ && pinfEq e₁ e₂
-    | .forallE _ t₁ e₁ bi₁, .forallE _ t₂ e₂ bi₂ =>
-      bi₁ == bi₂ && pinfEq t₁ t₂ && pinfEq e₁ e₂
-    | .letE _ t₁ v₁ e₁ _, .letE _ t₂ v₂ e₂ _ =>
-      pinfEq v₁ v₂ && pinfEq t₁ t₂ && pinfEq e₁ e₂
+    | .lam _ t₁ e₁ bi₁, .lam _ t₂ e₂ bi₂
+    | .forallE _ t₁ e₁ bi₁, .forallE _ t₂ e₂ bi₂ => bi₁ == bi₂ && pinfEq t₁ t₂ && pinfEq e₁ e₂
+    | .letE _ t₁ v₁ e₁ _, .letE _ t₂ v₂ e₂ _ => pinfEq v₁ v₂ && pinfEq t₁ t₂ && pinfEq e₁ e₂
     | .lit l₁, .lit l₂ => l₁ == l₂
-    | .mdata d e₁, e₂ | e₁, .mdata d e₂ => mdataIsProof d || pinfEq e₁ e₂
+    | .proj n₁ i₁ e₁, .proj n₂ i₂ e₂ => i₁ == i₂ && n₁ == n₂ && pinfEq e₁ e₂
+    | .mdata d e₁, e₂
+    | e₁, .mdata d e₂ => mdataIsProof d || pinfEq e₁ e₂
     | _, _ => false
 
   @[inherit_doc pinfEqCore]
@@ -100,8 +99,8 @@ instance : ToFormat (PINFRaw md) where
 instance : ToMessageData (PINFRaw md) where
   toMessageData x := toMessageData x.toExpr
 
-/-- An expression in PINF at `reducible` transparency. -/
-abbrev RPINFRaw := PINFRaw .reducible
+/-- An expression in PINF at `instances` transparency. -/
+abbrev RPINFRaw := PINFRaw .instances
 
 set_option linter.missingDocs false in
 /-- Cache for `rpinf`. -/
@@ -140,6 +139,6 @@ instance : ToMessageData (PINF md) where
   toMessageData x := toMessageData x.toExpr
 
 /-- An expression in RPINF together with its RPINF hash. -/
-abbrev RPINF := PINF .reducible
+abbrev RPINF := PINF .instances
 
 end Aesop

--- a/Aesop/RuleTac/Forward.lean
+++ b/Aesop/RuleTac/Forward.lean
@@ -99,7 +99,7 @@ partial def makeForwardHyps (e : Expr) (patSubst? : Option Substitution)
 def assertForwardHyp (goal : MVarId) (hyp : Hypothesis) (depth : Nat) :
     ScriptM (FVarId × MVarId) := do
   withScriptStep goal (λ (_, g) => #[g]) (λ _ => true) tacticBuilder do
-  withReducible do
+  withReducibleAndInstances do
     let hyp := {
       hyp with
       binderInfo := .default
@@ -122,7 +122,7 @@ def applyForwardRule (goal : MVarId) (e : Expr)
     (immediate : UnorderedArraySet PremiseIndex) (clear : Bool)
     (maxDepth? : Option Nat) (existingHypTypes : PHashSet RPINF) :
     ScriptM Subgoal :=
-  withReducible $ goal.withContext do
+  withReducibleAndInstances $ goal.withContext do
     let initialGoal := goal
     let forwardHypData ← getForwardHypData
     let mut newHypProofs := #[]

--- a/AesopTest/ForwardInstanceTransparency.lean
+++ b/AesopTest/ForwardInstanceTransparency.lean
@@ -1,0 +1,49 @@
+import Aesop
+
+-- This test case was the motivation for switching the transparency at which forward
+-- reasoning operates from `reducible` to `instances`.
+
+def PNat := { n : Nat // 0 < n }
+
+class AddCommMagma (α : Type u) extends Add α where
+  add_comm : ∀ x y : α, x + y = y + x
+
+export AddCommMagma (add_comm)
+
+instance lt_pnat : LT PNat :=
+  ⟨fun x y => x.1 < y.1⟩
+
+@[simp] theorem PNat.lt_def (x y : PNat) : x < y ↔ x.1 < y.1 := by rfl
+
+theorem Nat.pos_add {x y : Nat} (hx : 0 < x) (hy : 0 < y) : 0 < x + y := by
+  omega
+
+instance : Add PNat where
+  add a b := ⟨a.val + b.val, Nat.pos_add a.property b.property⟩
+
+@[simp] theorem PNat.add_def (x y : PNat) : x + y = ⟨x.val + y.val, Nat.pos_add x.property y.property⟩ := rfl
+
+instance : AddCommMagma PNat where
+  add a b := Add.add a b
+  add_comm a b := by simp [Nat.add_comm]
+
+theorem LT.lt.trans_eq [LT α] {x y : α} : x < y → y = z → x < z := by
+  intro h₁ h₂; rwa [h₂] at h₁
+
+theorem PNat.lt_add_left (m n : PNat) : n < m + n := by
+  simp [m.property]
+
+-- Here we use the `Add PNat` instance for the `+` notation.
+-- set_option pp.all true in
+-- #check PNat.lt_add_left
+
+-- Here we use the `AddCommMagma.toAdd` instance.
+-- set_option pp.all true in
+-- #check add_comm
+
+-- The instances are defeq at `instances` transparency, but not at `reducible`
+-- transparency.
+
+example (n m : PNat) : n < n + m := by
+  saturate [LT.lt.trans_eq, PNat.lt_add_left, add_comm]
+  assumption

--- a/AesopTest/ForwardTransparency.lean
+++ b/AesopTest/ForwardTransparency.lean
@@ -9,7 +9,7 @@ import Aesop
 set_option aesop.check.all true
 set_option aesop.smallErrorMessages true
 
--- Forward rules always operate at reducible transparency.
+-- Forward rules always operate at reducible+instances transparency.
 
 def T := Unit → Empty
 

--- a/AesopTest/SaturatePerformance.lean
+++ b/AesopTest/SaturatePerformance.lean
@@ -44,8 +44,8 @@ l0 l1 l2 : List α
 fwd : l0.length ≥ 0
 fwd_1 : l1.length ≥ 0
 fwd_2 : l2.length ≥ 0
-fwd_3 : (l0 ++ l1).length ≥ 0
-fwd_4 : (l0 ++ l1 ++ l2).length ≥ 0
+fwd_3 : (l0.append l1).length ≥ 0
+fwd_4 : ((l0.append l1).append l2).length ≥ 0
 ⊢ (l0 ++ l1 ++ l2).length = l0.length + l1.length + l2.length
 -/
 #guard_msgs in


### PR DESCRIPTION
Forward reasoning did not work with instances that are defeq at `instances`
transparency, but not at `reducible` transparency. This is common, so we want
to support it.
